### PR TITLE
bcm53xx: 6.6: fix ASM cache workaround linking

### DIFF
--- a/target/linux/bcm53xx/patches-6.6/300-ARM-BCM5301X-Disable-MMU-and-Dcache-during-decompres.patch
+++ b/target/linux/bcm53xx/patches-6.6/300-ARM-BCM5301X-Disable-MMU-and-Dcache-during-decompres.patch
@@ -99,3 +99,13 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
  	subs	r9, r9, #1			@ decrement the index
  	bge	loop2
  	subs	r4, r4, #1			@ decrement the way
+--- a/arch/arm/boot/compressed/vmlinux.lds.S
++++ b/arch/arm/boot/compressed/vmlinux.lds.S
+@@ -41,6 +41,7 @@ SECTIONS
+     *(.start)
+     *(.text)
+     *(.text.*)
++    *(.init.text)
+     ARM_STUBS_TEXT
+   }
+   .table : ALIGN(4) {


### PR DESCRIPTION
Kernel 6.6 checks for orphan sections and prints a warning about them, which in turn will make CI fails as we have Werror enabled there.

Issue is that cache-v7-min.S produces .init.text section which is an orphan section since it is not being handled by the vmlinux.lds.S linker script.

So, lets put the generated .init.text section under .text.

Fixes: f0d8ce4f482c ("bcm53xx: add testing support for kernel 6.6")

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
